### PR TITLE
Specify a duration before a response is returned

### DIFF
--- a/Codenizer.HttpClient.Testable.sln
+++ b/Codenizer.HttpClient.Testable.sln
@@ -5,11 +5,16 @@ VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{C0192DBD-4673-4573-BF61-FD0B4EFB7D11}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Codenizer.HttpClient.Testable", "src\Codenizer.HttpClient.Testable\Codenizer.HttpClient.Testable.csproj", "{CDCAE294-2AE2-4384-84AC-31DE18E095D2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Codenizer.HttpClient.Testable", "src\Codenizer.HttpClient.Testable\Codenizer.HttpClient.Testable.csproj", "{CDCAE294-2AE2-4384-84AC-31DE18E095D2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{F761F081-0182-4511-BAE1-57A351175020}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Codenizer.HttpClient.Testable.Tests.Unit", "test\Codenizer.HttpClient.Testable.Tests.Unit\Codenizer.HttpClient.Testable.Tests.Unit.csproj", "{0A28E5CE-0EDC-490A-8D28-34C79EA7D8DA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Codenizer.HttpClient.Testable.Tests.Unit", "test\Codenizer.HttpClient.Testable.Tests.Unit\Codenizer.HttpClient.Testable.Tests.Unit.csproj", "{0A28E5CE-0EDC-490A-8D28-34C79EA7D8DA}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{61B5BDEC-5FE6-4196-A6A0-566E9012E2A9}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,9 +24,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{CDCAE294-2AE2-4384-84AC-31DE18E095D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -49,8 +51,14 @@ Global
 		{0A28E5CE-0EDC-490A-8D28-34C79EA7D8DA}.Release|x86.ActiveCfg = Release|Any CPU
 		{0A28E5CE-0EDC-490A-8D28-34C79EA7D8DA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{CDCAE294-2AE2-4384-84AC-31DE18E095D2} = {C0192DBD-4673-4573-BF61-FD0B4EFB7D11}
 		{0A28E5CE-0EDC-490A-8D28-34C79EA7D8DA} = {F761F081-0182-4511-BAE1-57A351175020}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1B1E1F5F-E61E-406A-BC8F-ED67E04D7987}
 	EndGlobalSection
 EndGlobal

--- a/Codenizer.HttpClient.Testable.v3.ncrunchsolution
+++ b/Codenizer.HttpClient.Testable.v3.ncrunchsolution
@@ -1,0 +1,6 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <AllowParallelTestExecution>True</AllowParallelTestExecution>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>

--- a/README.md
+++ b/README.md
@@ -193,8 +193,36 @@ The handler will not serialize the data itself because it does not know about th
 AndHeaders(Dictionary<string, string> headers)
 ```
 
+For example:
+
+```csharp
+handler
+    .RespondTo(HttpMethod.Get, "/api/info/latest")
+    .With(HttpStatus.OK)
+    .AndContent("application/json", serializedJson)
+    .AndHeaders(new Dictionary<string, string>
+                {
+                    {"Test-Header", "SomeValue"}
+                });
+```
+
 If you need specific HTTP headers on the response you can add them using this method.
 This method can be called multiple times but be aware that it will append values to existing header names.
+
+### Delaying responses
+
+Let's say you want to test timeouts in your code, it would be useful to have the handler simulate that a request takes some time to process.
+With `Taking(TimeSpan time)` you can do that:
+
+```csharp
+handler
+    .RespondTo(HttpMethod.Get, "/api/info/latest")
+    .With(HttpStatus.OK)
+    .AndContent("application/json", serializedJson)
+    .Taking(TimeSpan.FromMilliseconds(100));
+```
+
+This will make the handler delay for 100ms before returning the response you've configured. You do not necissarily need to define content first, `Taking()` can be applied to `With()` directly.
 
 ### Verifying requests have been made
 

--- a/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
+++ b/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -7,7 +7,7 @@
   <PropertyGroup>
 
     <IsPackable>true</IsPackable>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <Title>Codenizer.HttpClient.Testable</Title>
     <Description>An easy way to test HttpClient interactions</Description>
     <Copyright>2018 Sander van Vliet</Copyright>

--- a/src/Codenizer.HttpClient.Testable/RequestBuilder.cs
+++ b/src/Codenizer.HttpClient.Testable/RequestBuilder.cs
@@ -1,10 +1,11 @@
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 
 namespace Codenizer.HttpClient.Testable
 {
-    public class RequestBuilder
+    public class RequestBuilder : IRequestBuilder, IResponseBuilder
     {
         public RequestBuilder(HttpMethod method, string pathAndQuery)
         {
@@ -18,14 +19,15 @@ namespace Codenizer.HttpClient.Testable
         public string Data { get; private set; }
         public string MediaType { get; private set; }
         public Dictionary<string, string> Headers { get; } = new Dictionary<string, string>();
+        public TimeSpan Duration { get; private set; } = TimeSpan.Zero;
 
-        public RequestBuilder With(HttpStatusCode httpStatusCode)
+        public IResponseBuilder With(HttpStatusCode httpStatusCode)
         {
             StatusCode = httpStatusCode;
             return this;
         }
 
-        public RequestBuilder AndContent(string mimeType, string data)
+        public IResponseBuilder AndContent(string mimeType, string data)
         {
             MediaType = mimeType;
             Data = data;
@@ -33,7 +35,7 @@ namespace Codenizer.HttpClient.Testable
             return this;
         }
 
-        public RequestBuilder AndHeaders(Dictionary<string, string> headers)
+        public IResponseBuilder AndHeaders(Dictionary<string, string> headers)
         {
             foreach (var header in headers)
             {
@@ -49,5 +51,24 @@ namespace Codenizer.HttpClient.Testable
             
             return this;
         }
+
+        public IResponseBuilder Taking(TimeSpan time)
+        {
+            Duration = time;
+
+            return this;
+        }
+    }
+
+    public interface IRequestBuilder
+    {
+        IResponseBuilder With(HttpStatusCode httpStatusCode);
+    }
+
+    public interface IResponseBuilder
+    {
+        IResponseBuilder AndContent(string mimeType, string data);
+        IResponseBuilder AndHeaders(Dictionary<string, string> headers);
+        IResponseBuilder Taking(TimeSpan time);
     }
 }

--- a/src/Codenizer.HttpClient.Testable/TestableMessageHandler.cs
+++ b/src/Codenizer.HttpClient.Testable/TestableMessageHandler.cs
@@ -64,15 +64,23 @@ namespace Codenizer.HttpClient.Testable
                 response.Headers.Add(header.Key, header.Value);
             }
 
+            if (responseBuilder.Duration > TimeSpan.Zero)
+            {
+                Task
+                    .Delay(responseBuilder.Duration, cancellationToken)
+                    .GetAwaiter()
+                    .GetResult();
+            }
+
             return Task.FromResult(response);
         }
 
-        public RequestBuilder RespondTo(string pathAndQuery)
+        public IRequestBuilder RespondTo(string pathAndQuery)
         {
             return RespondTo(HttpMethod.Get, pathAndQuery);
         }
 
-        public RequestBuilder RespondTo(HttpMethod method, string pathAndQuery)
+        public IRequestBuilder RespondTo(HttpMethod method, string pathAndQuery)
         {
             var requestBuilder = new RequestBuilder(method, pathAndQuery);
             


### PR DESCRIPTION
This PR introduces the option to specify how long the handler will wait before returning a response. You can use this to verify if your code is behaving when you configure time outs on the HttpClient.

See the README.md for usage instructions.