### PR TITLE
Add Content-Type matching and callback on request

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,25 @@ handler
 
 This will make the handler delay for 100ms before returning the response you've configured. You do not necissarily need to define content first, `Taking()` can be applied to `With()` directly.
 
+### Handle requests only if they match a content type
+
+You may want to configure a response only if the request has a specific `Content-Type`, for example on `PUT` or `POST` endpoints that require `application/json`.
+As of version `0.4.0` you can now do that like so:
+
+```csharp
+handler
+    .RespondTo(HttpMethod.Post, "/api/infos/", "application/json")
+    .With(HttpStatus.Created);
+```
+
+If you make a request with a content type of `text/plain`:
+
+```csharp
+await httpClient.PostAsync("/api/infos", new StringContent("test", Encoding.ASCII, "text/plain"));
+```
+
+the response returned from the handler will be `415 Unsupported Media Type`
+
 ### Verifying requests have been made
 
 The handler exposes a `Requests` property that contains all requests made to the handler. You can use [FluentAssertions](https://github.com/fluentassertions/fluentassertions/) to assert the properties of the requests.
@@ -236,3 +255,19 @@ _handler
     .Should()
     .Contain(req => req.RequestUri.PathAndQuery == "/api/info");
 ```
+
+### Callback when request is made
+
+For some cases it may be useful to have a callback when the request is handled by the testable handler. You can use `WhenCalled` to register one:
+
+```csharp
+var wasCalled = false;
+
+handler
+    .RespondTo(HttpMethod.Get, "/api/info/latest")
+    .With(HttpStatus.OK)
+    .AndContent("application/json", serializedJson)
+    .WhenCalled(request => wasCalled = true);
+```
+
+When you make a request to `/api/info/latest` the `wasCalled` variable will now be set to `true`.

--- a/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
+++ b/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
 
     <IsPackable>true</IsPackable>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <Title>Codenizer.HttpClient.Testable</Title>
     <Description>An easy way to test HttpClient interactions</Description>
     <Copyright>2018 Sander van Vliet</Copyright>

--- a/src/Codenizer.HttpClient.Testable/RequestBuilder.cs
+++ b/src/Codenizer.HttpClient.Testable/RequestBuilder.cs
@@ -7,13 +7,15 @@ namespace Codenizer.HttpClient.Testable
 {
     public class RequestBuilder : IRequestBuilder, IResponseBuilder
     {
-        public RequestBuilder(HttpMethod method, string pathAndQuery)
+        public RequestBuilder(HttpMethod method, string pathAndQuery, string contentType)
         {
             Method = method;
             PathAndQuery = pathAndQuery;
+            ContentType = contentType;
         }
 
         public string PathAndQuery { get; }
+        public string ContentType { get; }
         public HttpStatusCode StatusCode { get; private set; } = HttpStatusCode.InternalServerError;
         public HttpMethod Method { get; }
         public string Data { get; private set; }

--- a/src/Codenizer.HttpClient.Testable/RequestBuilder.cs
+++ b/src/Codenizer.HttpClient.Testable/RequestBuilder.cs
@@ -20,6 +20,7 @@ namespace Codenizer.HttpClient.Testable
         public string MediaType { get; private set; }
         public Dictionary<string, string> Headers { get; } = new Dictionary<string, string>();
         public TimeSpan Duration { get; private set; } = TimeSpan.Zero;
+        public Action<HttpRequestMessage> ActionWhenCalled { get; private set; }
 
         public IResponseBuilder With(HttpStatusCode httpStatusCode)
         {
@@ -58,6 +59,13 @@ namespace Codenizer.HttpClient.Testable
 
             return this;
         }
+
+        public IResponseBuilder WhenCalled(Action<HttpRequestMessage> action)
+        {
+            ActionWhenCalled = action;
+
+            return this;
+        }
     }
 
     public interface IRequestBuilder
@@ -70,5 +78,6 @@ namespace Codenizer.HttpClient.Testable
         IResponseBuilder AndContent(string mimeType, string data);
         IResponseBuilder AndHeaders(Dictionary<string, string> headers);
         IResponseBuilder Taking(TimeSpan time);
+        IResponseBuilder WhenCalled(Action<HttpRequestMessage> action);
     }
 }

--- a/src/Codenizer.HttpClient.Testable/TestableMessageHandler.cs
+++ b/src/Codenizer.HttpClient.Testable/TestableMessageHandler.cs
@@ -49,6 +49,8 @@ namespace Codenizer.HttpClient.Testable
 
             var responseBuilder = matches.Single();
 
+            responseBuilder.ActionWhenCalled?.Invoke(request);
+
             var response = new HttpResponseMessage
             {
                 StatusCode = responseBuilder.StatusCode

--- a/src/Codenizer.HttpClient.Testable/TestableMessageHandler.cs
+++ b/src/Codenizer.HttpClient.Testable/TestableMessageHandler.cs
@@ -31,7 +31,8 @@ namespace Codenizer.HttpClient.Testable
             Requests.Add(request);
 
             var matches = _configuredRequests
-                .Where(r => r.PathAndQuery == request.RequestUri.PathAndQuery && r.Method == request.Method)
+                .Where(r => r.PathAndQuery == request.RequestUri.PathAndQuery && 
+                            r.Method == request.Method)
                 .ToList();
 
             if(!matches.Any())
@@ -48,6 +49,19 @@ namespace Codenizer.HttpClient.Testable
             }
 
             var responseBuilder = matches.Single();
+
+            if (!string.IsNullOrWhiteSpace(responseBuilder.ContentType))
+            {
+                var requestContentType = request.Content.Headers.ContentType.MediaType;
+
+                if (requestContentType != responseBuilder.ContentType)
+                {
+                    return Task.FromResult(new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.UnsupportedMediaType
+                    });
+                }
+            }
 
             responseBuilder.ActionWhenCalled?.Invoke(request);
 
@@ -84,10 +98,15 @@ namespace Codenizer.HttpClient.Testable
 
         public IRequestBuilder RespondTo(HttpMethod method, string pathAndQuery)
         {
-            var requestBuilder = new RequestBuilder(method, pathAndQuery);
-            
+            return RespondTo(method, pathAndQuery, null);
+        }
+
+        public IRequestBuilder RespondTo(HttpMethod method, string pathAndQuery, string contentType)
+        {
+            var requestBuilder = new RequestBuilder(method, pathAndQuery, contentType);
+
             _configuredRequests.Add(requestBuilder);
-            
+
             return requestBuilder;
         }
 

--- a/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenHandlingRequest.cs
+++ b/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenHandlingRequest.cs
@@ -145,15 +145,13 @@ namespace Codenizer.HttpClient.Testable.Tests.Unit
         {
             var handler = new TestableMessageHandler();
             var client = new System.Net.Http.HttpClient(handler);
-            var wasCalled = false;
 
             handler
                 .RespondTo(
                     HttpMethod.Put,
                     "/api/hello?foo=bar",
                     "application/json")
-                .With(HttpStatusCode.NoContent)
-                .WhenCalled(request => wasCalled = true);
+                .With(HttpStatusCode.NoContent);
 
             var response = await client.PutAsync("https://tempuri.org/api/hello?foo=bar", new StringContent("foo", Encoding.ASCII,"text/plain"));
 

--- a/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenHandlingRequest.cs
+++ b/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenHandlingRequest.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
 using FluentAssertions;
 using Xunit;
 
@@ -136,6 +138,29 @@ namespace Codenizer.HttpClient.Testable.Tests.Unit
             wasCalled
                 .Should()
                 .BeTrue();
+        }
+
+        [Fact]
+        public async void GivenRequestIsConfiguredWithSpecificContentTypeAndRequestHasDifferentContentType_UnsupportedMediaTypeIsReturned()
+        {
+            var handler = new TestableMessageHandler();
+            var client = new System.Net.Http.HttpClient(handler);
+            var wasCalled = false;
+
+            handler
+                .RespondTo(
+                    HttpMethod.Put,
+                    "/api/hello?foo=bar",
+                    "application/json")
+                .With(HttpStatusCode.NoContent)
+                .WhenCalled(request => wasCalled = true);
+
+            var response = await client.PutAsync("https://tempuri.org/api/hello?foo=bar", new StringContent("foo", Encoding.ASCII,"text/plain"));
+
+            response
+                .StatusCode
+                .Should()
+                .Be(HttpStatusCode.UnsupportedMediaType);
         }
     }
 }

--- a/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenHandlingRequest.cs
+++ b/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenHandlingRequest.cs
@@ -118,5 +118,24 @@ namespace Codenizer.HttpClient.Testable.Tests.Unit
                 .Should()
                 .BeGreaterOrEqualTo(100);
         }
+
+        [Fact]
+        public async void GivenWhenCalledActionConfigured_ActionIsCalledWhenRequestIsMade()
+        {
+            var handler = new TestableMessageHandler();
+            var client = new System.Net.Http.HttpClient(handler);
+            var wasCalled = false;
+
+            handler
+                .RespondTo("/api/hello?foo=bar")
+                .With(HttpStatusCode.NoContent)
+                .WhenCalled(request => wasCalled = true);
+
+            await client.GetAsync("https://tempuri.org/api/hello?foo=bar");
+
+            wasCalled
+                .Should()
+                .BeTrue();
+        }
     }
 }


### PR DESCRIPTION
This PR allows you to match requests on `Content-Type` and to supply an action to be called when the request is handled.