### PR TITLE
Capture request before throwing exception

### DIFF
--- a/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
+++ b/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
 
     <IsPackable>true</IsPackable>
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
     <Title>Codenizer.HttpClient.Testable</Title>
     <Description>An easy way to test HttpClient interactions</Description>
     <Copyright>2019 Sander van Vliet</Copyright>

--- a/src/Codenizer.HttpClient.Testable/TestableMessageHandler.cs
+++ b/src/Codenizer.HttpClient.Testable/TestableMessageHandler.cs
@@ -22,12 +22,12 @@ namespace Codenizer.HttpClient.Testable
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            if(_exceptionToThrow != null)
+            Requests.Add(request);
+
+            if (_exceptionToThrow != null)
             {
                 throw _exceptionToThrow;
             }
-
-            Requests.Add(request);
 
             var match = RouteDictionary
                 .From(_configuredRequests)

--- a/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenConfiguringHandler.cs
+++ b/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenConfiguringHandler.cs
@@ -22,6 +22,27 @@ namespace Codenizer.HttpClient.Testable.Tests.Unit
                 .Throw<Exception>()
                 .WithMessage("BANG");
         }
+        [Fact]
+        public void GivenExceptionShouldBeThrown_RequestIsCaptured()
+        {
+            var handler = new TestableMessageHandler();
+            var client = new System.Net.Http.HttpClient(handler);
+
+            handler.ShouldThrow(new Exception("BANG"));
+
+            try
+            {
+                client.GetAsync("https://tempuri.org/api/hello").GetAwaiter().GetResult();
+            }
+            catch
+            {   
+            }
+
+            handler
+                .Requests
+                .Should()
+                .HaveCount(1);
+        }
 
         [Fact]
         public void GivenTwoResponsesForSamePath_MultipleResponsesExceptionIsThrown()


### PR DESCRIPTION
When you configure the handler to throw an exception via `ShouldThrow()` the handler now captures the request before actually throwing the exception.
This allows you to check that a request was actually made.