### PR TITLE
Fix single root segment matching bug

### DIFF
--- a/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
+++ b/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
 
     <IsPackable>true</IsPackable>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Title>Codenizer.HttpClient.Testable</Title>
     <Description>An easy way to test HttpClient interactions</Description>
     <Copyright>2019 Sander van Vliet</Copyright>
@@ -24,6 +24,11 @@
 
   <PropertyGroup>
     <DocumentationFile>.\Codenizer.HttpClient.Testable.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   
 </Project>

--- a/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
+++ b/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   

--- a/src/Codenizer.HttpClient.Testable/RouteDictionary.cs
+++ b/src/Codenizer.HttpClient.Testable/RouteDictionary.cs
@@ -56,7 +56,15 @@ namespace Codenizer.HttpClient.Testable
                     pointer.Segments.Add(part, segment);
                     pointer = segment;
 
-                    if (index == routeParts.Length - 1) pointer.RequestBuilders.Add(route.Method, route);
+                    if (index == routeParts.Length - 1)
+                    {
+                        pointer.RequestBuilders.Add(route.Method, route);
+                    }
+                }
+
+                if (routeParts.Length == 1)
+                {
+                    routeDictionary.RootSegments[pointer.Part].RequestBuilders.Add(route.Method, route);
                 }
             }
 

--- a/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenBuildingRouteDictionary.cs
+++ b/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenBuildingRouteDictionary.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using FluentAssertions;
 using Xunit;
@@ -61,6 +63,25 @@ namespace Codenizer.HttpClient.Testable.Tests.Unit
                 .Segments["foo"]
                 .Segments["bar?blah=blurb"]
                 .RequestBuilders[HttpMethod.Get]
+                .Should()
+                .Be(requestBuilder);
+        }
+
+        [Fact]
+        public void GivenPathForSingleDocumentAtRoot_RootSegmentContainsRequestBuilder()
+        {
+            var requestBuilder = new RequestBuilder(HttpMethod.Post, "/index.php", null);
+
+            var routes = new List<RequestBuilder>
+            {
+                requestBuilder
+            };
+
+            var dictionary = RouteDictionary.From(routes);
+
+            dictionary
+                .RootSegments["index.php"]
+                .RequestBuilders[HttpMethod.Post]
                 .Should()
                 .Be(requestBuilder);
         }


### PR DESCRIPTION
This PR fixes an issue where a path with a single root segment, for example: `/index.php`, would never be matched.