### PR TITLE
Add AndCookie method to response builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,31 @@ handler
 If you need specific HTTP headers on the response you can add them using this method.
 This method can be called multiple times but be aware that it will append values to existing header names.
 
+### Cookies
+
+If a response should include cookies you can configure the request with the `AndCookie` method:
+
+```csharp
+handler
+    .RespondTo(HttpMethod.Get, "/api/info/latest")
+    .With(HttpStatus.OK)
+    .AndContent("application/json", serializedJson)
+    .AndCookie("cookie-name", "cookie-value");
+```
+
+This will add the `Set-Cookie` HTTP header to the response. The `AndCookie` method supports the following parameters:
+
+- `expiresAt`, `DateTme` will only be added to the cookie if this value is not `null`
+- `domain`, `string` will only be added to the cookie if this value is not `null`
+- `path`, `string` will only be added to the cookie if this value is not `null`
+- `secure`, `bool` will only be added to the cookie if this value is `true`
+- `sameSite` (`Lax`, `Strict`, `None`), if left `null` the `SameSite` parameter will not be set on the cookie
+- `maxAge`, `int` will only be added to the cookie if this value is not `null`
+
+See the [MDN article](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie) on the `Set-Cookie` header for more details on valid values.
+
+If `AddCookie` does not suit your specific case you can always use `AddHeaders` and format the `Set-Cookie` header yourself. This can be particularly useful if you want to test malformed cookie responses.
+
 ### Delaying responses
 
 Let's say you want to test timeouts in your code, it would be useful to have the handler simulate that a request takes some time to process.

--- a/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
+++ b/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
@@ -7,10 +7,10 @@
   <PropertyGroup>
 
     <IsPackable>true</IsPackable>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <Title>Codenizer.HttpClient.Testable</Title>
     <Description>An easy way to test HttpClient interactions</Description>
-    <Copyright>2019 Sander van Vliet</Copyright>
+    <Copyright>2020 Sander van Vliet</Copyright>
     <Authors>Sander van Vliet</Authors>
     <PackageProjectUrl>https://github.com/sandermvanvliet/TestableHttpClient/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/sandermvanvliet/TestableHttpClient/LICENSE</PackageLicenseUrl>

--- a/src/Codenizer.HttpClient.Testable/TestableMessageHandler.cs
+++ b/src/Codenizer.HttpClient.Testable/TestableMessageHandler.cs
@@ -35,6 +35,7 @@ namespace Codenizer.HttpClient.Testable
             _configuredRequests = new List<RequestBuilder>();
         }
 
+        /// <inheritdoc />
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             Requests.Add(request);
@@ -88,6 +89,11 @@ namespace Codenizer.HttpClient.Testable
             foreach (var header in responseBuilder.Headers)
             {
                 response.Headers.Add(header.Key, header.Value);
+            }
+
+            foreach (var cookie in responseBuilder.Cookies)
+            {
+                response.Headers.Add("Set-Cookie", cookie);
             }
 
             if (responseBuilder.Duration > TimeSpan.Zero)


### PR DESCRIPTION
This PR adds the `AndCookie` method to the response builder to have a more convenient way of adding cookies to a configured response.

Instead of having to format the `Set-Cookie` header via the `AndHeaders` method, this PR now provides `AndCookie("name", "value")` to simplify your test cases.