### PR TITLE
Fix an issue with test hangs

### DIFF
--- a/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
+++ b/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
 
     <IsPackable>true</IsPackable>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Title>Codenizer.HttpClient.Testable</Title>
     <Description>An easy way to test HttpClient interactions</Description>
     <Copyright>2020 Sander van Vliet</Copyright>

--- a/src/Codenizer.HttpClient.Testable/TestableMessageHandler.cs
+++ b/src/Codenizer.HttpClient.Testable/TestableMessageHandler.cs
@@ -98,7 +98,7 @@ namespace Codenizer.HttpClient.Testable
 
             if (responseBuilder.Duration > TimeSpan.Zero)
             {
-                await Task.Delay(responseBuilder.Duration, cancellationToken);
+                Thread.Sleep((int)responseBuilder.Duration.TotalMilliseconds);
             }
 
             return response;


### PR DESCRIPTION
This PR fixes an issue where tests would hang when running in Azure DevOps.
The root cause seems to be with `Task.Delay`, however I was unable to actually _prove_ this short of replacing it with a `Thread.Sleep` that made the problem go away.