### PR TITLE
Add support for configuring responses with query string wild cards

### DIFF
--- a/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
+++ b/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
 
     <IsPackable>true</IsPackable>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <Title>Codenizer.HttpClient.Testable</Title>
     <Description>An easy way to test HttpClient interactions</Description>
     <Copyright>2020 Sander van Vliet</Copyright>

--- a/src/Codenizer.HttpClient.Testable/QueryStringAssertion.cs
+++ b/src/Codenizer.HttpClient.Testable/QueryStringAssertion.cs
@@ -1,0 +1,9 @@
+namespace Codenizer.HttpClient.Testable
+{
+    public class QueryStringAssertion
+    {
+        public string Key { get; set; }
+        public bool AnyValue { get; set; }
+        public string Value { get; set; }
+    }
+}

--- a/src/Codenizer.HttpClient.Testable/RequestBuilderForQueryString.cs
+++ b/src/Codenizer.HttpClient.Testable/RequestBuilderForQueryString.cs
@@ -1,0 +1,28 @@
+namespace Codenizer.HttpClient.Testable
+{
+    internal class RequestBuilderForQueryString : IRequestBuilderForQueryString
+    {
+        private readonly RequestBuilder _requestBuilder;
+        private readonly string _key;
+
+        public RequestBuilderForQueryString(RequestBuilder requestBuilder, string key)
+        {
+            _requestBuilder = requestBuilder;
+            _key = key;
+        }
+
+        public IRequestBuilder WithAnyValue()
+        {
+            _requestBuilder.QueryStringAssertions.Add(new QueryStringAssertion { Key = _key, AnyValue = true });
+
+            return _requestBuilder;
+        }
+
+        public IRequestBuilder WithValue(string value)
+        {
+            _requestBuilder.QueryStringAssertions.Add(new QueryStringAssertion { Key = _key, Value = value });
+
+            return _requestBuilder;
+        }
+    }
+}

--- a/src/Codenizer.HttpClient.Testable/RouteSegment.cs
+++ b/src/Codenizer.HttpClient.Testable/RouteSegment.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 
 namespace Codenizer.HttpClient.Testable
@@ -7,11 +8,118 @@ namespace Codenizer.HttpClient.Testable
     {
         public string Part { get; }
         public Dictionary<string, RouteSegment> Segments { get; } = new Dictionary<string, RouteSegment>();
-        public Dictionary<HttpMethod, RequestBuilder> RequestBuilders { get; } = new Dictionary<HttpMethod, RequestBuilder>();
+        
+        private readonly Dictionary<HttpMethod, List<RequestBuilder>> _requestBuildersWithParameters = new Dictionary<HttpMethod, List<RequestBuilder>>();
 
         public RouteSegment(string part)
         {
             Part = part;
+        }
+
+        public bool HasForQueryParameters(HttpMethod method)
+        {
+            if (!_requestBuildersWithParameters.ContainsKey(method))
+            {
+                return false;
+            }
+
+            return _requestBuildersWithParameters.ContainsKey(method);
+        }
+
+        public RequestBuilder GetForQueryParameters(HttpMethod method, Dictionary<string, string> queryParameters)
+        {
+            var all = _requestBuildersWithParameters[method];
+
+            foreach (var b in all)
+            {
+                if (b.QueryParameters.All(kv =>
+                    queryParameters.ContainsKey(kv.Key)))
+                {
+                    var match = b;
+
+                    foreach (var kv in b.QueryParameters)
+                    {
+                        var assertion = b.QueryStringAssertions.SingleOrDefault(a => a.Key == kv.Key);
+
+                        if (assertion != null)
+                        {
+                            if (!assertion.AnyValue && assertion.Value != queryParameters[kv.Key])
+                            {
+                                match = null;
+                                break;
+                            }
+                        }
+                        else if (b.QueryParameters[kv.Key] != queryParameters[kv.Key])
+                        {
+                            match = null;
+                            break;
+                        }
+                    }
+
+                    if (match != null)
+                    {
+                        return match;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public void Add(RequestBuilder route)
+        {
+            if (!_requestBuildersWithParameters.ContainsKey(route.Method))
+            {
+                _requestBuildersWithParameters.Add(route.Method, new List<RequestBuilder>());
+            }
+
+            // If this route has no query parameters and there is already a route without query parameters
+            // then we can't add it.
+            if (!route.QueryParameters.Any() &&
+                _requestBuildersWithParameters[route.Method].Any() &&
+                _requestBuildersWithParameters[route.Method].All(r => !r.QueryParameters.Any()))
+            {
+                throw new MultipleResponsesConfiguredException(2, route.PathAndQuery);
+            }
+
+            if(route.QueryParameters.Any())
+            {
+                var othersWithParameters = _requestBuildersWithParameters[route.Method]
+                    .Where(r => r.QueryParameters.Any())
+                    .ToList();
+
+                foreach (var b in othersWithParameters)
+                {
+                    if (b.QueryParameters.All(kv =>
+                        route.QueryParameters.ContainsKey(kv.Key) &&
+                        route.QueryParameters[kv.Key] == kv.Value))
+                    {
+                        throw new MultipleResponsesConfiguredException(2, route.PathAndQuery);
+                    }
+                }
+            }
+
+            _requestBuildersWithParameters[route.Method].Add(route);
+        }
+
+        public RequestBuilder GetWithoutQueryParameters(HttpMethod method)
+        {
+            if (!_requestBuildersWithParameters.ContainsKey(method))
+            {
+                return null;
+            }
+
+            if (_requestBuildersWithParameters[method].Count == 0)
+            {
+                return null;
+            }
+
+            if (_requestBuildersWithParameters[method].Count > 1)
+            {
+                throw new MultipleResponsesConfiguredException(_requestBuildersWithParameters[method].Count, method + " has responses with query parameters, use GetForQueryParameters() instead");
+            }
+
+            return _requestBuildersWithParameters[method].Single();
         }
     }
 }

--- a/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenBuildingRouteDictionary.cs
+++ b/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenBuildingRouteDictionary.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net;
+﻿using System.Collections.Generic;
 using System.Net.Http;
 using FluentAssertions;
 using Xunit;
@@ -41,7 +39,7 @@ namespace Codenizer.HttpClient.Testable.Tests.Unit
                 .RootSegments["api"]
                 .Segments["foo"]
                 .Segments["bar"]
-                .RequestBuilders[HttpMethod.Get]
+                .GetWithoutQueryParameters(HttpMethod.Get)
                 .Should()
                 .Be(requestBuilder);
         }
@@ -61,10 +59,32 @@ namespace Codenizer.HttpClient.Testable.Tests.Unit
             dictionary
                 .RootSegments["api"]
                 .Segments["foo"]
-                .Segments["bar?blah=blurb"]
-                .RequestBuilders[HttpMethod.Get]
+                .Segments["bar"]
+                .GetWithoutQueryParameters(HttpMethod.Get)
                 .Should()
                 .Be(requestBuilder);
+        }
+
+        [Fact]
+        public void GivenPathWithQueryParameters_TailSegmentContainsQueryParameters()
+        {
+            var requestBuilder = new RequestBuilder(HttpMethod.Get, "/api/foo/bar?blah=blurb", null);
+
+            var routes = new List<RequestBuilder>
+            {
+                requestBuilder
+            };
+
+            var dictionary = RouteDictionary.From(routes);
+
+            dictionary
+                .RootSegments["api"]
+                .Segments["foo"]
+                .Segments["bar"]
+                .GetWithoutQueryParameters(HttpMethod.Get)
+                .QueryParameters
+                .Should()
+                .Contain("blah", "blurb");
         }
 
         [Fact]
@@ -81,7 +101,7 @@ namespace Codenizer.HttpClient.Testable.Tests.Unit
 
             dictionary
                 .RootSegments["index.php"]
-                .RequestBuilders[HttpMethod.Post]
+                .GetWithoutQueryParameters(HttpMethod.Post)
                 .Should()
                 .Be(requestBuilder);
         }

--- a/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenMatchingRoutes.cs
+++ b/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenMatchingRoutes.cs
@@ -41,7 +41,7 @@ namespace Codenizer.HttpClient.Testable.Tests.Unit
 
             dictionary
                 .Match(
-                    HttpMethod.Get, 
+                    HttpMethod.Get,
                     "/api/baz")
                 .Should()
                 .BeNull();
@@ -61,7 +61,7 @@ namespace Codenizer.HttpClient.Testable.Tests.Unit
 
             dictionary
                 .Match(
-                    HttpMethod.Get, 
+                    HttpMethod.Get,
                     "/api/foos/1234")
                 .Should()
                 .Be(requestBuilder);
@@ -81,10 +81,49 @@ namespace Codenizer.HttpClient.Testable.Tests.Unit
 
             dictionary
                 .Match(
-                    HttpMethod.Get, 
+                    HttpMethod.Get,
                     "/api/foos/1234/?blah=baz")
                 .Should()
                 .Be(requestBuilder);
+        }
+
+        [Fact]
+        public void GivenRouteWithParameterAndQueryStringWithoutSeparator_RequestBuilderIsReturned()
+        {
+            var requestBuilder = new RequestBuilder(HttpMethod.Get, "/api/foos/{id}?blah=baz", null);
+
+            var routes = new List<RequestBuilder>
+            {
+                requestBuilder
+            };
+
+            var dictionary = RouteDictionary.From(routes);
+
+            dictionary
+                .Match(
+                    HttpMethod.Get,
+                    "/api/foos/1234?blah=baz")
+                .Should()
+                .Be(requestBuilder);
+        }
+
+        [Fact]
+        public void GivenRouteWithParameterAndQueryStringWithoutSeparatorX_RequestBuilderIsReturned()
+        {
+            var routes = new List<RequestBuilder>
+            {
+                new RequestBuilder(HttpMethod.Get, "/api/foos/{id}?blah=baz", null),
+                new RequestBuilder(HttpMethod.Get, "/api/foos/{id}?blah=qux", null)
+            };
+
+            var dictionary = RouteDictionary.From(routes);
+
+            dictionary
+                .Match(
+                    HttpMethod.Get,
+                    "/api/foos/1234?blah=qux")
+                .Should()
+                .Be(routes[1]);
         }
     }
 }


### PR DESCRIPTION
When you need to test an endpoint where a query string parameter is changing but not important to the test you can configure a response like so:

```csharp
handler
                .RespondTo(HttpMethod.Get, "/api/entity/{id}?key=value&someFilter=another")
                .ForQueryStringParameter("key").WithAnyValue()
                .With(HttpStatusCode.OK);
```

This will now match the following responses:

- `GET /api/entity/123?key=blah&someFilter=another`
- `GET /api/entity/123?key=foo&someFilter=another`
- `GET /api/entity/123?key=barbazquux&someFilter=another`

This can be particularly useful in scenarios for testing OAuth flows where you have a nonce or state parameter that constantly changes.