### PR TITLE
Fix an issue where slashes in query parameters were used as route segments

### DIFF
--- a/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
+++ b/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
 
     <IsPackable>true</IsPackable>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <Title>Codenizer.HttpClient.Testable</Title>
     <Description>An easy way to test HttpClient interactions</Description>
     <Copyright>2020 Sander van Vliet</Copyright>

--- a/src/Codenizer.HttpClient.Testable/RouteDictionary.cs
+++ b/src/Codenizer.HttpClient.Testable/RouteDictionary.cs
@@ -145,7 +145,16 @@ namespace Codenizer.HttpClient.Testable
 
         private static string[] PathAndQueryToSegments(string pathAndQuery)
         {
-            return pathAndQuery.Split(new[] {'/'}, StringSplitOptions.RemoveEmptyEntries);
+            var parts = pathAndQuery.Split(new[] {'?'}, StringSplitOptions.RemoveEmptyEntries);
+
+            var pathAndQueryToSegments = parts[0].Split(new[] {'/'}, StringSplitOptions.RemoveEmptyEntries).ToList();
+
+            if (parts.Length == 2)
+            {
+                pathAndQueryToSegments[pathAndQueryToSegments.Count - 1] += "?" + parts[1];
+            }
+
+            return pathAndQueryToSegments.ToArray();
         }
     }
 }

--- a/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenHandlingRequest.cs
+++ b/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenHandlingRequest.cs
@@ -325,5 +325,24 @@ namespace Codenizer.HttpClient.Testable.Tests.Unit
                 .Should()
                 .Be(HttpStatusCode.InternalServerError);
         }
+
+        [Fact]
+        public async void Repro()
+        {
+            var handler = new TestableMessageHandler();
+            var client = new System.Net.Http.HttpClient(handler);
+
+            handler
+                .RespondTo(HttpMethod.Get,
+                    "/signin-service/v1/consent/users/840f9c5a-12f6-434f-83c4-6ba605f41092/09b6cbec-cd19-4589-82fd-363dfa8c24da@apps_vw-dilab_com?scopes=address%20profile%20badge%20birthdate%20birthplace%20nationalIdentifier%20nationality%20profession%20email%20vin%20phone%20nickname%20name%20picture%20mbb%20gallery%20openid&relayState=b512822e924ef060fe820c8bbcaabe85859d2035&callback=https://identity.vwgroup.io/oidc/v1/oauth/client/callback&hmac=a63faea3311a0b4296df53ed94d617b241a2e078f080f9997e0d4d9cee2f07f3")
+                .With(HttpStatusCode.Found);
+
+            var response = await client.GetAsync("https://identity.vwgroup.io/signin-service/v1/consent/users/840f9c5a-12f6-434f-83c4-6ba605f41092/09b6cbec-cd19-4589-82fd-363dfa8c24da@apps_vw-dilab_com?scopes=address%20profile%20badge%20birthdate%20birthplace%20nationalIdentifier%20nationality%20profession%20email%20vin%20phone%20nickname%20name%20picture%20mbb%20gallery%20openid&relayState=b512822e924ef060fe820c8bbcaabe85859d2035&callback=https://identity.vwgroup.io/oidc/v1/oauth/client/callback&hmac=a63faea3311a0b4296df53ed94d617b241a2e078f080f9997e0d4d9cee2f07f3");
+
+            response
+                .StatusCode
+                .Should()
+                .Be(HttpStatusCode.Found);
+        }
     }
 }


### PR DESCRIPTION
When configuring a route like `/api/entity/something?foo=bar&callback=https://tempuri.org/foo/bar` the parts of the `callback` query parameter were incorrectly included as route segments.