### PR TITLE
Handle query parameters that only have a key

### DIFF
--- a/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
+++ b/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
 
     <IsPackable>true</IsPackable>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
     <Title>Codenizer.HttpClient.Testable</Title>
     <Description>An easy way to test HttpClient interactions</Description>
     <Copyright>2020 Sander van Vliet</Copyright>

--- a/src/Codenizer.HttpClient.Testable/RequestBuilder.cs
+++ b/src/Codenizer.HttpClient.Testable/RequestBuilder.cs
@@ -31,7 +31,7 @@ namespace Codenizer.HttpClient.Testable
                 QueryParameters = parts[1]
                     .Split('&')
                     .Select(p => p.Split('='))
-                    .ToDictionary(p => p[0], p => p[1]);
+                    .ToDictionary(p => p[0], p => p.Length == 2 ? p[1] : null);
             }
 
             ContentType = contentType;

--- a/src/Codenizer.HttpClient.Testable/RouteDictionary.cs
+++ b/src/Codenizer.HttpClient.Testable/RouteDictionary.cs
@@ -83,7 +83,7 @@ namespace Codenizer.HttpClient.Testable
                 queryParameters = parts[1]
                     .Split('&')
                     .Select(p => p.Split('='))
-                    .ToDictionary(p => p[0], p => p[1]);
+                    .ToDictionary(p => p[0], p => p.Length == 2 ? p[1] : null);
             }
 
             if (segments.Last() == "")

--- a/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenHandlingRequest.cs
+++ b/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenHandlingRequest.cs
@@ -327,7 +327,7 @@ namespace Codenizer.HttpClient.Testable.Tests.Unit
         }
 
         [Fact]
-        public async void Repro()
+        public async void GivenUriHasQueryParameterWithSlashes_OnlyRoutePartIsMatched()
         {
             var handler = new TestableMessageHandler();
             var client = new System.Net.Http.HttpClient(handler);
@@ -338,6 +338,24 @@ namespace Codenizer.HttpClient.Testable.Tests.Unit
                 .With(HttpStatusCode.Found);
 
             var response = await client.GetAsync("https://identity.vwgroup.io/signin-service/v1/consent/users/840f9c5a-12f6-434f-83c4-6ba605f41092/09b6cbec-cd19-4589-82fd-363dfa8c24da@apps_vw-dilab_com?scopes=address%20profile%20badge%20birthdate%20birthplace%20nationalIdentifier%20nationality%20profession%20email%20vin%20phone%20nickname%20name%20picture%20mbb%20gallery%20openid&relayState=b512822e924ef060fe820c8bbcaabe85859d2035&callback=https://identity.vwgroup.io/oidc/v1/oauth/client/callback&hmac=a63faea3311a0b4296df53ed94d617b241a2e078f080f9997e0d4d9cee2f07f3");
+
+            response
+                .StatusCode
+                .Should()
+                .Be(HttpStatusCode.Found);
+        }
+
+        [Fact]
+        public async void GivenUriHasQueryParameterWithoutValues_RouteIsMatchedSuccessfully()
+        {
+            var handler = new TestableMessageHandler();
+            var client = new System.Net.Http.HttpClient(handler);
+
+            handler
+                .RespondTo(HttpMethod.Get, "/api/entity/blah?foo&bar&baz")
+                .With(HttpStatusCode.Found);
+
+            var response = await client.GetAsync("https://tempuri.org/api/entity/blah?foo&bar&baz");
 
             response
                 .StatusCode


### PR DESCRIPTION
When configuring a response for a URL like: `/api/entity/foo?bar&baz&qux` the route builder failed because it was expecting all query parameters to have a value.