### PR TITLE
Properly time-out when requested

### DIFF
--- a/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
+++ b/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
 
     <IsPackable>true</IsPackable>
-    <Version>1.3.2</Version>
+    <Version>1.3.3</Version>
     <Title>Codenizer.HttpClient.Testable</Title>
     <Description>An easy way to test HttpClient interactions</Description>
     <Copyright>2020 Sander van Vliet</Copyright>

--- a/src/Codenizer.HttpClient.Testable/TestableMessageHandler.cs
+++ b/src/Codenizer.HttpClient.Testable/TestableMessageHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -98,7 +99,14 @@ namespace Codenizer.HttpClient.Testable
 
             if (responseBuilder.Duration > TimeSpan.Zero)
             {
-                Thread.Sleep((int)responseBuilder.Duration.TotalMilliseconds);
+                var stopwatch = Stopwatch.StartNew();
+
+                while (stopwatch.ElapsedMilliseconds < responseBuilder.Duration.TotalMilliseconds)
+                {
+                    Thread.Sleep(5);
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
             }
 
             return response;

--- a/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenHandlingRequest.cs
+++ b/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenHandlingRequest.cs
@@ -123,6 +123,27 @@ namespace Codenizer.HttpClient.Testable.Tests.Unit
         }
 
         [Fact]
+        public void GivenResponseDurationConfiguredAndHttpClientHasTimeout_OperationCanceledExceptionIsThrown()
+        {
+            var handler = new TestableMessageHandler();
+            var client = new System.Net.Http.HttpClient(handler)
+            {
+                Timeout = TimeSpan.FromMilliseconds(50)
+            };
+
+            handler
+                .RespondTo("/api/hello?foo=bar")
+                .With(HttpStatusCode.NoContent)
+                .Taking(TimeSpan.FromMilliseconds(100));
+
+            Action action = () => client.GetAsync("https://tempuri.org/api/hello?foo=bar").GetAwaiter().GetResult();
+
+            action
+                .Should()
+                .Throw<OperationCanceledException>();
+        }
+
+        [Fact]
         public async void GivenWhenCalledActionConfigured_ActionIsCalledWhenRequestIsMade()
         {
             var handler = new TestableMessageHandler();


### PR DESCRIPTION
The `Timeout` property on the `HttpClient` is applied using the `CancellationToken` that is passed to the handler. This PR now correctly uses that to simulate time-outs in the handler.