### PR TITLE
Add support for a sequence of response

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,24 @@ await httpClient.PostAsync("/api/infos", new StringContent("test", Encoding.ASCI
 
 the response returned from the handler will be `415 Unsupported Media Type`
 
+### A sequence of responses
+
+In some cases you might want to have multiple responses configured for the same endpoint, for example when you call a status endpoint of a job.
+Using `WithSequence` you can configure an ordered set of responses for a single endpoint:
+
+```csharp
+handler
+    .RespondTo(HttpMethod.Get, "/api/status")
+    .WithSequence(builder => builder.With(HttpStatusCode.OK).AndContent("text/plain", "PENDING"))
+    .WithSequence(builder => builder.With(HttpStatusCode.OK).AndContent("text/plain", "PENDING"))
+    .WithSequence(builder => builder.With(HttpStatusCode.OK).AndContent("text/plain", "PENDING"))
+    .WithSequence(builder => builder.With(HttpStatusCode.OK).AndContent("text/plain", "OK"));
+```
+
+here we have an endpoint `/api/status` that will respond with the content `OK` on the 4th call.
+
+The `builder` argument is a new `IRequestBuilder` instance that you can configure the specific response with for the step in the sequence. It allows you to use all the options of configuring a response like you would have when you use `With()`.
+
 ### Verifying requests have been made
 
 The handler exposes a `Requests` property that contains all requests made to the handler. You can use [FluentAssertions](https://github.com/fluentassertions/fluentassertions/) to assert the properties of the requests.

--- a/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
+++ b/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
@@ -7,10 +7,10 @@
   <PropertyGroup>
 
     <IsPackable>true</IsPackable>
-    <Version>1.3.3</Version>
+    <Version>1.4.0</Version>
     <Title>Codenizer.HttpClient.Testable</Title>
     <Description>An easy way to test HttpClient interactions</Description>
-    <Copyright>2020 Sander van Vliet</Copyright>
+    <Copyright>2021 Sander van Vliet</Copyright>
     <Authors>Sander van Vliet</Authors>
     <PackageProjectUrl>https://github.com/sandermvanvliet/TestableHttpClient/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/sandermvanvliet/TestableHttpClient/LICENSE</PackageLicenseUrl>

--- a/src/Codenizer.HttpClient.Testable/TestableMessageHandler.cs
+++ b/src/Codenizer.HttpClient.Testable/TestableMessageHandler.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -61,6 +62,19 @@ namespace Codenizer.HttpClient.Testable
             }
 
             var responseBuilder = match;
+
+            if (responseBuilder.ResponseSequence.Any())
+            {
+                if (responseBuilder.ResponseSequenceCounter >= responseBuilder.ResponseSequence.Count)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                    {
+                        Content = new StringContent($"Received request number {responseBuilder.ResponseSequenceCounter+1} for {request.RequestUri.PathAndQuery} but only {responseBuilder.ResponseSequence.Count} responses were configured")
+                    };
+                }
+
+                responseBuilder = responseBuilder.ResponseSequence[responseBuilder.ResponseSequenceCounter++];
+            }
 
             if (!string.IsNullOrWhiteSpace(responseBuilder.ContentType))
             {

--- a/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenHandlingRequestWithSequence.cs
+++ b/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenHandlingRequestWithSequence.cs
@@ -1,0 +1,81 @@
+﻿using System.Net;
+using System.Net.Http;
+using FluentAssertions;
+using Xunit;
+
+namespace Codenizer.HttpClient.Testable.Tests.Unit
+{
+    public class WhenHandlingRequestWithSequence
+    {
+        [Fact]
+        public void GivenSequenceWithThreeResponses_AllThreeResponsesAreReturned()
+        {
+            var handler = new TestableMessageHandler();
+            var client = new System.Net.Http.HttpClient(handler);
+
+            handler
+                .RespondTo("/api/hello")
+                .WithSequence(builder => builder
+                    .With(HttpStatusCode.OK)
+                    .AndContent("text/plain", "response 1"))
+                .WithSequence(builder => builder
+                    .With(HttpStatusCode.OK)
+                    .AndContent("text/plain", "response 2"))
+                .WithSequence(builder => builder
+                    .With(HttpStatusCode.OK)
+                    .AndContent("text/plain", "response 3"));
+                
+
+            var response1 = client.GetAsync("https://tempuri.org/api/hello").GetAwaiter().GetResult();
+            var response2 = client.GetAsync("https://tempuri.org/api/hello").GetAwaiter().GetResult();
+            var response3 = client.GetAsync("https://tempuri.org/api/hello").GetAwaiter().GetResult();
+
+            ContentOf(response1).Should().Be("response 1");
+            ContentOf(response2).Should().Be("response 2");
+            ContentOf(response3).Should().Be("response 3");
+        }
+
+        [Fact]
+        public void GivenSequenceWithThreeResponsesAndFourRequests_LastRequestResultsInInternalServerError()
+        {
+            var handler = new TestableMessageHandler();
+            var client = new System.Net.Http.HttpClient(handler);
+
+            handler
+                .RespondTo("/api/hello")
+                .WithSequence(builder => builder
+                    .With(HttpStatusCode.OK)
+                    .AndContent("text/plain", "response 1"))
+                .WithSequence(builder => builder
+                    .With(HttpStatusCode.OK)
+                    .AndContent("text/plain", "response 2"))
+                .WithSequence(builder => builder
+                    .With(HttpStatusCode.OK)
+                    .AndContent("text/plain", "response 3"));
+                
+            client.GetAsync("https://tempuri.org/api/hello").GetAwaiter().GetResult();
+            client.GetAsync("https://tempuri.org/api/hello").GetAwaiter().GetResult();
+            client.GetAsync("https://tempuri.org/api/hello").GetAwaiter().GetResult();
+            var lastResponse = client.GetAsync("https://tempuri.org/api/hello").GetAwaiter().GetResult();
+
+            lastResponse
+                .StatusCode
+                .Should()
+                .Be(HttpStatusCode.InternalServerError);
+
+            ContentOf(lastResponse)
+                .Should()
+                .Be("Received request number 4 for /api/hello but only 3 responses were configured");
+        }
+
+        private string ContentOf(HttpResponseMessage response)
+        {
+            if (response.Content != null)
+            {
+                return response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This adds `WithSequence` so you can do:

```csharp
handler
    .RespondTo(HttpMethod.Get, "/api/status")
    .WithSequence(builder => builder.With(HttpStatusCode.OK).AndContent("text/plain", "PENDING"))
    .WithSequence(builder => builder.With(HttpStatusCode.OK).AndContent("text/plain", "PENDING"))
    .WithSequence(builder => builder.With(HttpStatusCode.OK).AndContent("text/plain", "PENDING"))
    .WithSequence(builder => builder.With(HttpStatusCode.OK).AndContent("text/plain", "OK"));
```