### PR TITLE
Add JSON or byte array responses and fix query string parameter bugs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,10 @@
+# Codenizer.HttpClient.Testable Changelog
+
+## 2.0.0
+
+- Added XML Doc comments on public methods and properties to improve documentation in the IDE
+- Added support for `AndJsonContent` that will serialize the provided object using either provided JSON serializer settings, the serializer settings configured on the testable handler or the default Json.Net serializer settings (in that order)
+- Added support for returning a `byte[]` response using `AndContent("application/octet-stream", new byte[] { /* data */ })`
+- Fix an issue where the testable handler did not support multiple query parameters with the same name (For example `/api/foo?bar=foo&bar=quux`), this is now supported and assertions for individual parameters too.
+
+The query string parameter bug fixed in this release needed a breaking change to support that properly the version number is bumped from `1.4.0` to `2.0.0`.

--- a/README.md
+++ b/README.md
@@ -199,7 +199,70 @@ handler
     .AndContent("application/json", serializedJson);
 ```
 
-The handler will not serialize the data itself because it does not know about the required serialization settings.
+Using `AndContent` the handler will not serialize the data itself because it does not know about the required serialization settings.
+
+#### Returning JSON data
+
+As most APIs tend to return JSON data a convenience method is introduced on the testable handler. You can configure a request using the `AndJsonContent` method:
+
+```csharp
+var myObject = new {
+    Foo = "bar",
+    Baz = "quux"
+};
+
+handler
+    .RespondTo(HttpMethod.Get, "/api/info/latest")
+    .With(HttpStatus.OK)
+    .AndJsonContent(myObject);
+```
+
+In this case the response received by a caller will be serialized using the **default** Json.Net serialization settings.
+
+To control how objects are serialized you can either pass a `JsonSerializerSettings` object to `AndJsonContent`:
+
+```csharp
+var myObject = new {
+    Foo = "bar",
+    Baz = "quux"
+};
+
+var serializerSettings = new JsonSerializerSettings
+{
+    /* settings */
+};
+
+handler
+    .RespondTo(HttpMethod.Get, "/api/info/latest")
+    .With(HttpStatus.OK)
+    .AndJsonContent(myObject, serializerSettings);
+```
+
+or if you have a handler for a specific API you can set that at construction time too:
+
+```csharp
+var serializerSettings = new JsonSerializerSettings
+{
+    /* settings */
+};
+
+var handler = new TestableMessageHandler(serializerSettings);
+```
+
+in this case the handler will use those settings when serializing the object to return.
+
+#### Returning binary data
+
+You can now also configure a response to return binary data by passing in a byte array to `AndContent`. This will result in a `ByteArrayContent` object being used on the response:
+
+```csharp
+var myPayload = new byte[] { 0x1, 0x2, 0x3 };
+
+handler
+    .RespondTo(HttpMethod.Get, "/api/info/latest")
+    .With(HttpStatus.OK)
+    .AndContent("image/png", myPayload);
+```
 
 ### Response headers
 

--- a/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
+++ b/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
 
     <IsPackable>true</IsPackable>
-    <Version>1.4.0</Version>
+    <Version>2.0.0</Version>
     <Title>Codenizer.HttpClient.Testable</Title>
     <Description>An easy way to test HttpClient interactions</Description>
     <Copyright>2021 Sander van Vliet</Copyright>
@@ -30,5 +30,9 @@
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
   
 </Project>

--- a/src/Codenizer.HttpClient.Testable/HttpRequestMessageExtensions.cs
+++ b/src/Codenizer.HttpClient.Testable/HttpRequestMessageExtensions.cs
@@ -2,6 +2,9 @@ using System.Net.Http;
 
 namespace Codenizer.HttpClient.Testable
 {
+    /// <summary>
+    /// Extension methods to improve usage patterns of the testable message handler
+    /// </summary>
     public static class HttpRequestMessageExtensions
     {
         /// <summary>

--- a/src/Codenizer.HttpClient.Testable/MultipleResponsesConfiguredException.cs
+++ b/src/Codenizer.HttpClient.Testable/MultipleResponsesConfiguredException.cs
@@ -16,6 +16,7 @@ namespace Codenizer.HttpClient.Testable
             PathAndQuery = pathAndQuery;
         }
 
+        /// <inheritdoc />
         protected MultipleResponsesConfiguredException(SerializationInfo info, StreamingContext context)
              : base(info, context)
         {
@@ -23,6 +24,7 @@ namespace Codenizer.HttpClient.Testable
             PathAndQuery = info.GetString("pathAndQuery");
         }
 
+        /// <inheritdoc />
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             info.AddValue("numberOfResponses", NumberOfResponses);

--- a/src/Codenizer.HttpClient.Testable/QueryStringAssertion.cs
+++ b/src/Codenizer.HttpClient.Testable/QueryStringAssertion.cs
@@ -1,9 +1,22 @@
 namespace Codenizer.HttpClient.Testable
 {
+    /// <summary>
+    /// Defines an assertion on a query string parameter
+    /// </summary>
     public class QueryStringAssertion
     {
+        /// <summary>
+        /// The name of the query string parameter
+        /// </summary>
         public string Key { get; set; }
+        /// <summary>
+        /// Flag indicating whether any value is considered valid.
+        /// </summary>
         public bool AnyValue { get; set; }
+        /// <summary>
+        /// The value to match on
+        /// </summary>
+        /// <remarks>This value is ignored if <see cref="AnyValue"/> is set to true</remarks>
         public string Value { get; set; }
     }
 }

--- a/src/Codenizer.HttpClient.Testable/RouteDictionary.cs
+++ b/src/Codenizer.HttpClient.Testable/RouteDictionary.cs
@@ -72,7 +72,7 @@ namespace Codenizer.HttpClient.Testable
         internal RequestBuilder Match(HttpMethod method, string pathAndQuery)
         {
             var segments = PathAndQueryToSegments(pathAndQuery);
-            var queryParameters = new Dictionary<string, string>();
+            var queryParameters = new List<KeyValuePair<string, string>>();
 
             if (segments.Last().Contains("?"))
             {
@@ -83,7 +83,8 @@ namespace Codenizer.HttpClient.Testable
                 queryParameters = parts[1]
                     .Split('&')
                     .Select(p => p.Split('='))
-                    .ToDictionary(p => p[0], p => p.Length == 2 ? p[1] : null);
+                    .Select(p => new KeyValuePair<string, string>(p[0],  p.Length == 2 ? p[1] : null))
+                    .ToList();
             }
 
             if (segments.Last() == "")

--- a/test/Codenizer.HttpClient.Testable.Tests.Unit/Codenizer.HttpClient.Testable.Tests.Unit.csproj
+++ b/test/Codenizer.HttpClient.Testable.Tests.Unit/Codenizer.HttpClient.Testable.Tests.Unit.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenBuildingRouteDictionary.cs
+++ b/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenBuildingRouteDictionary.cs
@@ -84,7 +84,7 @@ namespace Codenizer.HttpClient.Testable.Tests.Unit
                 .GetWithoutQueryParameters(HttpMethod.Get)
                 .QueryParameters
                 .Should()
-                .Contain("blah", "blurb");
+                .Contain(new KeyValuePair<string, string>("blah", "blurb"));
         }
 
         [Fact]


### PR DESCRIPTION
- Added XML Doc comments on public methods and properties to improve documentation in the IDE
- Added support for `AndJsonContent` that will serialize the provided object using either provided JSON serializer settings, the serializer settings configured on the testable handler or the default Json.Net serializer settings (in that order)
- Added support for returning a `byte[]` response using `AndContent("application/octet-stream", new byte[] { /* data */ })`
- Fix an issue where the testable handler did not support multiple query parameters with the same name (For example `/api/foo?bar=foo&bar=quux`), this is now supported and assertions for individual parameters too.

The query string parameter bug fixed in this release needed a breaking change to support that properly the version number is bumped from `1.4.0` to `2.0.0`.