### PR TITLE
Fix matching paths

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,18 @@
 # Codenizer.HttpClient.Testable Changelog
 
+## 2.2.1
+
+This release fixes an issue where paths would get a match if when they shouldn't.
+
+```http
+GET /foo/bar
+```
+
+would also match
+```http
+GET /foo/v1/bar
+```
+
 ## 2.2.0
 
 This release changes the target frameworks for the test project to netcore 3.1, net5 and net6.

--- a/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
+++ b/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <Version>2.2.0</Version>
+    <Version>2.2.1</Version>
     <Title>A HTTP handler for unit testing</Title>
     <Description>An easy way to test HttpClient interactions in unit tests</Description>
     <Copyright>2022 Sander van Vliet</Copyright>

--- a/src/Codenizer.HttpClient.Testable/RouteDictionary.cs
+++ b/src/Codenizer.HttpClient.Testable/RouteDictionary.cs
@@ -128,6 +128,10 @@ namespace Codenizer.HttpClient.Testable
                             {
                                 pointer = pointer.Segments[first];
                             }
+                            else
+                            {
+                                return null;
+                            }
                         }
                         else
                         {

--- a/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenMatchingRoutes.cs
+++ b/test/Codenizer.HttpClient.Testable.Tests.Unit/WhenMatchingRoutes.cs
@@ -255,5 +255,20 @@ namespace Codenizer.HttpClient.Testable.Tests.Unit
                 .Should()
                 .Be("baz/quux");
         }
+
+        [Fact]
+        public void GivenRouteHasExtraPartInPath_ShouldNotReturnAMatch()
+        {
+            var routes = new List<RequestBuilder>
+            {
+                new RequestBuilder(HttpMethod.Post, "/api/foos/1/bla-bla", "application/json"),
+            };
+
+            var dictionary = RouteDictionary.From(routes);
+
+            dictionary.Match(HttpMethod.Post, "/api/v2/foos/1/bla-bla", "application/json")
+                .Should()
+                .BeNull();
+        }
     }
 }


### PR DESCRIPTION
if there is a route configured that would mostly match.

say something like: `/api/foo`
and you would change it to `/api/v2/foo`
it would return the response of the old request, instead of returning an error