### PR TITLE
Add TestableHttpClientFactory to support IHttpClientFactory usage

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,54 @@
 # Codenizer.HttpClient.Testable Changelog
 
+## 2.5.0
+
+This release adds the `TestableHttpClientFactory` to help with scenarios where you are using a `IHttpClientFactory` in your code:
+
+**The code under test:**
+
+```csharp
+public class TheRealComponent
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public TheRealComponent(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public async Task<string> ExecuteAsync()
+    {
+        var httpClient = _httpClientFactory.CreateClient("TheNameOfTheClient");
+        return await httpClient.GetStringAsync("https://example.com");
+    }
+}
+```
+
+**The test:**
+
+```csharp
+var httpClientFactory = new TestableHttpClientFactory();
+var handler = httpClientFactory.ConfigureClient("TheNameOfTheClient");
+
+handler
+    .RespondTo()
+    .Get()
+    .ForUrl("https://example.com")
+    .With(HttpStatus.OK)
+    .AndContent("text/plain", "Hello, world!");
+
+var sut = new TheRealComponent(httpClientFactory);
+
+var result = await sut.ExecuteAsync();
+
+result
+    .Should()
+    .Be("Hello, world!");
+```
+
+The `TestableHttpClientFactory` will return a new `HttpClient` instance which is backed by the `TestableMessageHandler` you've configured in the test.
+
+
 ## 2.4.0
 
 This release fixes an issue where in some cases the `Content` of the captured request would not be accessible because the original `HttpRequestMessage` was aready disposed.

--- a/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
+++ b/src/Codenizer.HttpClient.Testable/Codenizer.HttpClient.Testable.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <Title>A HTTP handler for unit testing</Title>
     <Description>An easy way to test HttpClient interactions in unit tests</Description>
     <Copyright>2022 Sander van Vliet</Copyright>
@@ -33,6 +33,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0">
+	    <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/src/Codenizer.HttpClient.Testable/TestableHttpClientFactory.cs
+++ b/src/Codenizer.HttpClient.Testable/TestableHttpClientFactory.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Net.Http;
+
+namespace Codenizer.HttpClient.Testable
+{
+    /// <summary>
+    /// A <see cref="IHttpClientFactory"/> that allows you to provide <see cref="HttpClient"/> instances that are backed by a <see cref="TestableMessageHandler"/>
+    /// </summary>
+    public class TestableHttpClientFactory : IHttpClientFactory
+    {
+        private readonly Dictionary<string, TestableMessageHandler> _clientConfigurations = new Dictionary<string, TestableMessageHandler>();
+
+        /// <inheritdoc cref="IHttpClientFactory.CreateClient"/>
+        public System.Net.Http.HttpClient CreateClient(string name)
+        {
+            if (!_clientConfigurations.ContainsKey(name))
+            {
+                // No client was configured but IHttpClientFactory.CreateClient
+                // requires us to return a new HttpClient instance. So we will
+                // return one but it's going to be backed by a default
+                // TestableMessageHandler. 
+                return new System.Net.Http.HttpClient(new TestableMessageHandler());
+            }
+
+            return new System.Net.Http.HttpClient(_clientConfigurations[name]);
+        }
+
+        /// <summary>
+        /// Configure a client name to return a <see cref="HttpClient"/> with the given handler
+        /// </summary>
+        /// <param name="name">The name of the <see cref="HttpClient"/> as requested by <see cref="CreateClient"/></param>
+        /// <param name="messageHandler">The <see cref="TestableMessageHandler"/> instance that should be used for the client name</param>
+        public void ConfigureClient(string name, TestableMessageHandler messageHandler)
+        {
+            _clientConfigurations.Add(name, messageHandler);
+        }
+
+        /// <summary>
+        /// Configure a client name to return a <see cref="HttpClient"/> with a <see cref="TestableMessageHandler"/>
+        /// </summary>
+        /// <param name="name">The name of the <see cref="HttpClient"/> as requested by <see cref="CreateClient"/></param>
+        /// <returns>The <see cref="TestableMessageHandler"/> instance that will be used for the client name</returns>
+        public TestableMessageHandler ConfigureClient(string name)
+        {
+            var messageHandler = new TestableMessageHandler();
+            _clientConfigurations.Add(name, messageHandler);
+            return messageHandler;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the `TestableHttpClientFactory` to help with scenarios where you are using a `IHttpClientFactory` in your code:

**The code under test:**

```csharp
public class TheRealComponent
{
    private readonly IHttpClientFactory _httpClientFactory;

    public TheRealComponent(IHttpClientFactory httpClientFactory)
    {
        _httpClientFactory = httpClientFactory;
    }

    public async Task<string> ExecuteAsync()
    {
        var httpClient = _httpClientFactory.CreateClient("TheNameOfTheClient");
        return await httpClient.GetStringAsync("https://example.com");
    }
}
```

**The test:**

```csharp
var httpClientFactory = new TestableHttpClientFactory();
var handler = httpClientFactory.ConfigureClient("TheNameOfTheClient");

handler
    .RespondTo()
    .Get()
    .ForUrl("https://example.com")
    .With(HttpStatus.OK)
    .AndContent("text/plain", "Hello, world!");

var sut = new TheRealComponent(httpClientFactory);

var result = await sut.ExecuteAsync();

result
    .Should()
    .Be("Hello, world!");
```

The `TestableHttpClientFactory` will return a new `HttpClient` instance which is backed by the `TestableMessageHandler` you've configured in the test.