### PR TITLE
Add Authorization header matching to IRequestBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,24 @@ await httpClient.PostAsync("/api/infos", new StringContent("test", Encoding.ASCI
 
 the response returned from the handler will be `415 Unsupported Media Type`
 
+
+### Handle requests only if they match the authorization header
+
+For some tests you might want to configure the handler to return when the correct authorization token is provided.
+
+To do this you can configure the handler like so:
+
+```csharp
+handler
+    .RespondTo()
+    .Post()
+    .ForUrl("/search")
+    .AndAuthorization(new AuthenticationHeaderValue("Scheme", "Value"))
+    .With(HttpStatusCode.OK);
+```
+
+This allows you to configure multiple responses to a url depending on the authorization of a request.
+
 ### Handle requests only if they match the request body
 
 For some tests you might want to configure the handler to return certain responses based on the request content.

--- a/src/Codenizer.HttpClient.Testable/IRequestBuilder.cs
+++ b/src/Codenizer.HttpClient.Testable/IRequestBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net;
+using System.Net.Http.Headers;
 
 namespace Codenizer.HttpClient.Testable
 {
@@ -87,6 +88,13 @@ namespace Codenizer.HttpClient.Testable
         /// <param name="contentType">A MIME content type (for example text/plain)</param>
         /// <returns>The current <see cref="IRequestBuilder"/> instance</returns>
         IRequestBuilder AndContentType(string contentType);
+
+        /// <summary>
+        /// Respond to a request that matches the authorization header
+        /// </summary>
+        /// <param name="authenticationHeader">A authorization header value</param>
+        /// <returns>The current <see cref="IRequestBuilder"/> instance</returns>
+        IRequestBuilder Authorization(AuthenticationHeaderValue authenticationHeader);
         
         /// <summary>
         /// Respond to a request that matches the accept header

--- a/src/Codenizer.HttpClient.Testable/IRequestBuilder.cs
+++ b/src/Codenizer.HttpClient.Testable/IRequestBuilder.cs
@@ -94,7 +94,7 @@ namespace Codenizer.HttpClient.Testable
         /// </summary>
         /// <param name="authenticationHeader">A authorization header value</param>
         /// <returns>The current <see cref="IRequestBuilder"/> instance</returns>
-        IRequestBuilder Authorization(AuthenticationHeaderValue authenticationHeader);
+        IRequestBuilder AndAuthorization(AuthenticationHeaderValue authenticationHeader);
         
         /// <summary>
         /// Respond to a request that matches the accept header

--- a/src/Codenizer.HttpClient.Testable/RequestBuilder.cs
+++ b/src/Codenizer.HttpClient.Testable/RequestBuilder.cs
@@ -252,7 +252,7 @@ namespace Codenizer.HttpClient.Testable
             return this;
         }
 
-        public IRequestBuilder Authorization(AuthenticationHeaderValue authenticationHeader) {
+        public IRequestBuilder AndAuthorization(AuthenticationHeaderValue authenticationHeader) {
             AuthorizationHeader = authenticationHeader;
             return this;
         }

--- a/src/Codenizer.HttpClient.Testable/RequestBuilder.cs
+++ b/src/Codenizer.HttpClient.Testable/RequestBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 
@@ -118,6 +119,12 @@ namespace Codenizer.HttpClient.Testable
         /// Optional. The value of the Accept header to match.
         /// </summary>
         public string? Accept { get; private set; }
+        
+        
+        /// <summary>
+        /// Optional. The value of the Accept header to match.
+        /// </summary>
+        public AuthenticationHeaderValue? AuthorizationHeader { get; private set; }
 
         /// <summary>
         /// Optional. The expected content of the request.
@@ -242,6 +249,11 @@ namespace Codenizer.HttpClient.Testable
             }
 
             ContentType = contentType;
+            return this;
+        }
+
+        public IRequestBuilder Authorization(AuthenticationHeaderValue authenticationHeader) {
+            AuthorizationHeader = authenticationHeader;
             return this;
         }
 
@@ -396,6 +408,11 @@ namespace Codenizer.HttpClient.Testable
         {
             var headers = new Dictionary<string, string>();
 
+            if (AuthorizationHeader is not null)
+            {
+                headers.Add("Authorization", AuthorizationHeader.ToString());
+            }
+            
             if (!string.IsNullOrEmpty(Accept))
             {
                 headers.Add("Accept", Accept!);


### PR DESCRIPTION
Leveraged the existing header matching node and added configurable headers. 